### PR TITLE
Fix documentation issues to address CRAN's notes

### DIFF
--- a/R/btsdemo.R
+++ b/R/btsdemo.R
@@ -11,15 +11,15 @@
 #'   \item uid unique company identifier
 #'   \item year numeric year column
 #'   \item weight quantitative weight
-#'   \item question\_1
-#'   \item question\_2
-#'   \item question\_3
-#'   \item question\_4
-#'   \item question\_5
-#'   \item group group to mimmick different sectors / branches of trade
+#'   \item question\eqn{_1}
+#'   \item question\eqn{_2}
+#'   \item question\eqn{_3}
+#'   \item question\eqn{_4}
+#'   \item question\eqn{_5}
+#'   \item group to mimmick different sectors / branches of trade
 #'   \item altGroup another alternative grouping columns
 #'   \item sClass a column denoting discrete size classes small (S), medium (M) and large (L)
-#'   \item date\_qtrly quarterly dates stored in a single column. 
+#'   \item date\eqn{_\text{qtrly}} quarterly dates stored in a single column. 
 #' }
 #'
 #' @author Matthias Bannert

--- a/R/doUniqueCJ.R
+++ b/R/doUniqueCJ.R
@@ -1,6 +1,6 @@
 #' Performs a Cross Join of Unique combinations
 #' 
-#' This function makes use of \code{\link{CJ}} function of the data.table package to perform a
+#' This function makes use of \code{\link[data.table]{CJ}} function of the data.table package to perform a
 #' cross join. The function makes sure that the combinations are unique and removes NAs before
 #' joining. doUniqueCJ is rather not used as a standalone function but inside \code{\link{computeShares}}. 
 #' 

--- a/man/btsdemo.Rd
+++ b/man/btsdemo.Rd
@@ -3,7 +3,9 @@
 \name{btsdemo}
 \alias{btsdemo}
 \title{Randomly Generated Panel Dataset}
-\format{A data frame with 27000 rows and 13 variables}
+\format{
+A data frame with 27000 rows and 13 variables
+}
 \source{
 Randomly generated in R using the sample generator from https://github.com/mbannert/gateveys/blob/master/R/gateveys.R
 }
@@ -19,18 +21,17 @@ its distribution is somewhat (!) reasonable with respect to the distribution of 
   \item uid unique company identifier
   \item year numeric year column
   \item weight quantitative weight
-  \item question\_1
-  \item question\_2
-  \item question\_3
-  \item question\_4
-  \item question\_5
-  \item group group to mimmick different sectors / branches of trade
+  \item question\eqn{_1}
+  \item question\eqn{_2}
+  \item question\eqn{_3}
+  \item question\eqn{_4}
+  \item question\eqn{_5}
+  \item group to mimmick different sectors / branches of trade
   \item altGroup another alternative grouping columns
   \item sClass a column denoting discrete size classes small (S), medium (M) and large (L)
-  \item date\_qtrly quarterly dates stored in a single column. 
+  \item date\eqn{_\text{qtrly}} quarterly dates stored in a single column. 
 }
 }
 \author{
 Matthias Bannert
 }
-

--- a/man/computeBalance.Rd
+++ b/man/computeBalance.Rd
@@ -4,8 +4,10 @@
 \alias{computeBalance}
 \title{Compute Balances from a Item Shares}
 \usage{
-computeBalance(data_table, multipliers = list(item_pos = 1, item_eq = 0,
-  item_neg = -1))
+computeBalance(
+  data_table,
+  multipliers = list(item_pos = 1, item_eq = 0, item_neg = -1)
+)
 }
 \arguments{
 \item{data_table}{a data.table in wide format containing item}
@@ -19,4 +21,3 @@ stored in a wide format data.table.
 \author{
 Matthias Bannert, Gabriel Bucu
 }
-

--- a/man/computeShares.Rd
+++ b/man/computeShares.Rd
@@ -104,4 +104,3 @@ plot(ts3, main = attributes(ts3)$ts_key)
 \author{
 Matthias Bannert, Gabriel Bucur, Oliver Mueller
 }
-

--- a/man/computeWeightedMeans.Rd
+++ b/man/computeWeightedMeans.Rd
@@ -102,4 +102,3 @@ plot(ts3, main = attributes(ts3)$ts_key)
 \author{
 Matthias Bannert, Gabriel Bucur
 }
-

--- a/man/doUniqueCJ.Rd
+++ b/man/doUniqueCJ.Rd
@@ -19,4 +19,3 @@ joining. doUniqueCJ is rather not used as a standalone function but inside \code
 \author{
 Matthias Bannert, Gabriel Bucur
 }
-

--- a/man/doUniqueCJ.Rd
+++ b/man/doUniqueCJ.Rd
@@ -12,7 +12,7 @@ doUniqueCJ(dt, cols)
 \item{cols}{character vector that denotes names of relevant columns}
 }
 \description{
-This function makes use of \code{\link{CJ}} function of the data.table package to perform a
+This function makes use of \code{\link[data.table]{CJ}} function of the data.table package to perform a
 cross join. The function makes sure that the combinations are unique and removes NAs before
 joining. doUniqueCJ is rather not used as a standalone function but inside \code{\link{computeShares}}.
 }

--- a/man/extractTimeSeries.Rd
+++ b/man/extractTimeSeries.Rd
@@ -4,8 +4,15 @@
 \alias{extractTimeSeries}
 \title{Extract a Time Series from a Data.table}
 \usage{
-extractTimeSeries(data_table, time_column, group_list, freq, item, variable,
-  prefix = "CH.KOF.IND")
+extractTimeSeries(
+  data_table,
+  time_column,
+  group_list,
+  freq,
+  item,
+  variable,
+  prefix = "CH.KOF.IND"
+)
 }
 \arguments{
 \item{data_table}{a data.table}
@@ -30,4 +37,3 @@ This function extracts time series from data.table columns and returns object of
 \author{
 Matthias Bannert, Gabriel Bucur
 }
-

--- a/man/joinDataTables.Rd
+++ b/man/joinDataTables.Rd
@@ -25,4 +25,3 @@ In the latter case, the sequence of the names is crucial. Make sure that the key
 \author{
 Matthias Bannert, Gabriel Bucur
 }
-


### PR DESCRIPTION
The package was archived on 2025-06-13, because the issues below:

```
Version: 0.1.1
Check: Rd files
Result: NOTE 
  checkRd: (-1) btsdemo.Rd:22: Escaped LaTeX specials: \_
  checkRd: (-1) btsdemo.Rd:23: Escaped LaTeX specials: \_
  checkRd: (-1) btsdemo.Rd:24: Escaped LaTeX specials: \_
  checkRd: (-1) btsdemo.Rd:25: Escaped LaTeX specials: \_
  checkRd: (-1) btsdemo.Rd:26: Escaped LaTeX specials: \_
  checkRd: (-1) btsdemo.Rd:30: Escaped LaTeX specials: \_
Flavors: [r-devel-linux-x86_64-debian-clang](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-debian-clang/panelaggregation-00check.html), [r-devel-linux-x86_64-debian-gcc](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-debian-gcc/panelaggregation-00check.html), [r-devel-linux-x86_64-fedora-clang](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-fedora-clang/panelaggregation-00check.html), [r-devel-linux-x86_64-fedora-gcc](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-fedora-gcc/panelaggregation-00check.html), [r-devel-windows-x86_64](https://www.r-project.org/nosvn/R.check/r-devel-windows-x86_64/panelaggregation-00check.html), [r-patched-linux-x86_64](https://www.r-project.org/nosvn/R.check/r-patched-linux-x86_64/panelaggregation-00check.html), [r-release-linux-x86_64](https://www.r-project.org/nosvn/R.check/r-release-linux-x86_64/panelaggregation-00check.html), [r-release-macos-arm64](https://www.r-project.org/nosvn/R.check/r-release-macos-arm64/panelaggregation-00check.html), [r-release-macos-x86_64](https://www.r-project.org/nosvn/R.check/r-release-macos-x86_64/panelaggregation-00check.html), [r-release-windows-x86_64](https://www.r-project.org/nosvn/R.check/r-release-windows-x86_64/panelaggregation-00check.html), [r-oldrel-macos-arm64](https://www.r-project.org/nosvn/R.check/r-oldrel-macos-arm64/panelaggregation-00check.html), [r-oldrel-macos-x86_64](https://www.r-project.org/nosvn/R.check/r-oldrel-macos-x86_64/panelaggregation-00check.html), [r-oldrel-windows-x86_64](https://www.r-project.org/nosvn/R.check/r-oldrel-windows-x86_64/panelaggregation-00check.html)

Version: 0.1.1
Check: Rd cross-references
Result: NOTE 
  Found the following Rd file(s) with Rd \link{} targets missing package
  anchors:
    doUniqueCJ.Rd: CJ
  Please provide package anchors for all Rd \link{} targets not in the
  package itself and the base packages.
Flavors: [r-devel-linux-x86_64-debian-clang](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-debian-clang/panelaggregation-00check.html), [r-devel-linux-x86_64-debian-gcc](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-debian-gcc/panelaggregation-00check.html), [r-devel-windows-x86_64](https://www.r-project.org/nosvn/R.check/r-devel-windows-x86_64/panelaggregation-00check.html), [r-patched-linux-x86_64](https://www.r-project.org/nosvn/R.check/r-patched-linux-x86_64/panelaggregation-00check.html), [r-release-linux-x86_64](https://www.r-project.org/nosvn/R.check/r-release-linux-x86_64/panelaggregation-00check.html), [r-release-windows-x86_64](https://www.r-project.org/nosvn/R.check/r-release-windows-x86_64/panelaggregation-00check.html)
```

See https://github.com/r-devel/r-dev-day/issues/110 for further context of these CRAN notes